### PR TITLE
Add containing group to fix a compiling Warning

### DIFF
--- a/visual-ascii-mode.el
+++ b/visual-ascii-mode.el
@@ -33,7 +33,8 @@
 
 (defgroup visual-ascii-mode nil
   "Visualize ascii code on buffer"
-  :prefix "visual-ascii-mode")
+  :prefix "visual-ascii-mode"
+  :group 'Convenience)
 
 (defcustom visual-ascii-mode-show-unicode nil
   "Non-nil means that any integer less than (max-char) will be recognized as


### PR DESCRIPTION
Quote from "(elisp) Group Definitions":

> The package's main or only group should be a member of one or more of
> the standard customization groups
